### PR TITLE
fix: ensure ZAHLUNGSART_MAIL_EINGANG is set on existing payment methods

### DIFF
--- a/Services/PostFinanceCheckoutPaymentService.php
+++ b/Services/PostFinanceCheckoutPaymentService.php
@@ -113,6 +113,17 @@ class PostFinanceCheckoutPaymentService
 		  ->select(self::TABLE_NAME_PAYMENT_METHODS, 'cModulId', $slug);
 
 		if ($paymentMethod) {
+			// Ensure ZAHLUNGSART_MAIL_EINGANG (0x0001) is always set so that
+			// the order confirmation email is sent after a successful payment.
+			// JTL's admin backend or installer can reset nMailSenden to 16
+			// (ZAHLUNGSART_MAIL_STORNO only), which prevents email delivery.
+			if (!((int)$paymentMethod->nMailSenden & 0x0001)) {
+				$upd = new \stdClass();
+				$upd->nMailSenden = (int)$paymentMethod->nMailSenden | 0x0001;
+				Shop::Container()
+				  ->getDB()
+				  ->update(self::TABLE_NAME_PAYMENT_METHODS, 'cModulId', $slug, $upd);
+			}
 			return null;
 		}
 


### PR DESCRIPTION
## Problem

When a payment method already exists in the database, `installPaymentMethod()` returns `null` immediately without updating `nMailSenden`. JTL's admin backend (`PaymentMethodsController.php`) or the JTL installer (`Installer.php`) can reset `nMailSenden` to `16` (`ZAHLUNGSART_MAIL_STORNO` only), which causes `canSendEmail()` in `PostFinanceCheckoutMailService.php` to always return `false` — so the order confirmation email is never sent after a successful payment.

## Root Cause

```php
// PostFinanceCheckoutPaymentService.php
if ($paymentMethod) {
    return null;  // existing method: nMailSenden is never corrected
}
```

The `canSendEmail()` check for `fulfill`:
```php
$data->tbestellung->Zahlungsart->nMailSenden & \ZAHLUNGSART_MAIL_EINGANG
```

With `nMailSenden = 16`: `16 & 1 = 0` → email blocked.

## Fix

When the payment method already exists, ensure `ZAHLUNGSART_MAIL_EINGANG` (`0x0001`) is always included in `nMailSenden`, while preserving all other flags (e.g. `ZAHLUNGSART_MAIL_STORNO = 16`).

## Impact

- No breaking changes — only adds the missing bit if absent
- Existing flags are preserved via bitwise OR
- Fixes intermittent missing order confirmation emails on long-running shops

## Reproduction

```sql
-- Check affected shops:
SELECT cName, nMailSenden FROM tzahlungsart
WHERE cModulId LIKE '%postfinancecheckout%';
-- nMailSenden = 16 → affected
-- nMailSenden = 17 → correct
```